### PR TITLE
t019까지 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,38 +1,23 @@
-plugins {
-    java
-    id("org.springframework.boot") version "3.5.5"
-    id("io.spring.dependency-management") version "1.1.7"
-}
+plugins { id("java") }
 
 group = "com"
-version = "0.0.1-SNAPSHOT"
-description = "SimpleDb-2509"
+version = "1.0-SNAPSHOT"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom(configurations.annotationProcessor.get())
-    }
-}
-
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter")
-    compileOnly("org.projectlombok:lombok")
-    runtimeOnly("com.mysql:mysql-connector-j")
-    annotationProcessor("org.projectlombok:lombok")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    compileOnly("org.projectlombok:lombok:1.18.38")
+    annotationProcessor("org.projectlombok:lombok:1.18.38")
+
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+
+    implementation("com.mysql:mysql-connector-j:9.3.0")
+
+    testImplementation("org.assertj:assertj-core:3.27.3")
+
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+tasks.test { useJUnitPlatform() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0")
+
+    implementation("ch.qos.logback:logback-classic:1.5.6")
 }
 
 tasks.test { useJUnitPlatform() }

--- a/src/main/java/com/back/BackApplication.java
+++ b/src/main/java/com/back/BackApplication.java
@@ -1,13 +1,8 @@
 package com.back;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-@SpringBootApplication
 public class BackApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(BackApplication.class, args);
     }
 
 }

--- a/src/main/java/com/back/domain/article/article/entity/Article.java
+++ b/src/main/java/com/back/domain/article/article/entity/Article.java
@@ -1,0 +1,4 @@
+package com.back.domain.article.article.entity;
+
+public class Article {
+}

--- a/src/main/java/com/back/domain/article/article/entity/Article.java
+++ b/src/main/java/com/back/domain/article/article/entity/Article.java
@@ -1,4 +1,18 @@
 package com.back.domain.article.article.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
 public class Article {
+    long id;
+    LocalDateTime createdDate;
+    LocalDateTime modifiedDate;
+    String title;
+    String body;
+    @JsonProperty("isBlind") boolean isBlind;
 }

--- a/src/main/java/com/back/domain/article/db/SimpleDb.java
+++ b/src/main/java/com/back/domain/article/db/SimpleDb.java
@@ -13,12 +13,16 @@ public class SimpleDb {
     // 개발 모드 활성화 여부
     private boolean devMode;
 
+    //각 스레드의 Connection을 독립적으로 저장하기 위한 ThreadLocal
+    private final ThreadLocal<Connection> connectionThreadLocal;
+
     // 생성자: DB 접속 정보를 받아 필드를 초기화합니다.
     public SimpleDb(String host, String user, String password, String dbName) {
         this.url = "jdbc:mysql://" + host + "/" + dbName + "?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul";
         this.user = user;
         this.password = password;
         this.devMode = false;
+        this.connectionThreadLocal = new ThreadLocal<>();
     }
 
     // 개발자 모드를 설정하는 메서드
@@ -29,6 +33,43 @@ public class SimpleDb {
     // 개발 모드인지 확인하는 내부용(package-private) 메서드
     boolean isDevMode() {
         return this.devMode;
+    }
+
+    Connection getConnection() {
+        //ThreadLocal에서 현재 스레드에 저장된 Connection을 가져옴
+        Connection conn = connectionThreadLocal.get();
+        try{
+            if (conn == null || conn.isClosed()){
+                // DriverManager를 통해 새로운 DB 연결을 생성
+                conn = DriverManager.getConnection(url, user, password);
+                connectionThreadLocal.set(conn);
+            }
+        } catch (SQLException e) {
+            // DB 연결 중 오류 발생 시, 런타임 예외로 전환하여 알림
+            throw new RuntimeException(e);
+        }
+        // 준비된 Connection 객체를 반환
+        return conn;
+    }
+
+    // [스레드 관리 해결] 현재 스레드에 할당된 Connection을 닫고 ThreadLocal에서 제거
+    public void close() {
+        // ThreadLocal에서 현재 스레드의 Connection을 가져옴
+        Connection conn = connectionThreadLocal.get();
+        // Connection이 존재하면
+        if (conn != null) {
+            try {
+                // Connection이 닫혀있지 않으면 실제로 닫음
+                if (!conn.isClosed()) {
+                    conn.close();
+                }
+            } catch (SQLException ignored) {
+                // close 과정에서 발생하는 예외는 일반적으로 무시함
+            } finally {
+                // 매우 중요: 메모리 누수 방지를 위해 ThreadLocal에서 반드시 제거
+                connectionThreadLocal.remove();
+            }
+        }
     }
 
     //결과값이 필요 없는 단순 SQL(CREATE, INSERT, TRUNCATE 등)을 실행하는 편의 메서드입니다.

--- a/src/main/java/com/back/domain/article/db/SimpleDb.java
+++ b/src/main/java/com/back/domain/article/db/SimpleDb.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class SimpleDb {
@@ -90,5 +89,31 @@ public class SimpleDb {
 
     public Sql genSql() {
         return new Sql(this);
+    }
+
+    //트랜잭션 시작
+    //자동으로 커밋되지 않게 합니다.
+    public void startTransaction() {
+        try{
+            getConnection().setAutoCommit(false);
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void commit() {
+        try {
+            getConnection().commit();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void rollback() {
+        try {
+            getConnection().rollback();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/back/domain/article/db/SimpleDb.java
+++ b/src/main/java/com/back/domain/article/db/SimpleDb.java
@@ -1,0 +1,43 @@
+package com.back.domain.article.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class SimpleDb {
+    // DB 접속 정보를 저장하는 필드 (package-private으로 변경하여 Sql 클래스에서 접근 가능하도록 수정)
+    final String url;
+    final String user;
+    final String password;
+    // 개발 모드 활성화 여부
+    private boolean devMode;
+
+    // 생성자: DB 접속 정보를 받아 필드를 초기화합니다.
+    public SimpleDb(String host, String user, String password, String dbName) {
+        this.url = "jdbc:mysql://" + host + "/" + dbName + "?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul";
+        this.user = user;
+        this.password = password;
+        this.devMode = false;
+    }
+
+    // 개발자 모드를 설정하는 메서드
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
+    }
+
+    // 개발 모드인지 확인하는 내부용(package-private) 메서드
+    boolean isDevMode() {
+        return this.devMode;
+    }
+
+    //결과값이 필요 없는 단순 SQL(CREATE, INSERT, TRUNCATE 등)을 실행하는 편의 메서드입니다.
+    public void run(String sql, Object... params) {
+        // 내부적으로 Sql 객체를 생성하고, append와 update를 연속으로 호출하여 SQL을 실행합니다.
+        new Sql(this).append(sql, params).update();
+    }
+
+    public Sql genSql() {
+        return new Sql(this);
+    }
+}

--- a/src/main/java/com/back/domain/article/db/SimpleDb.java
+++ b/src/main/java/com/back/domain/article/db/SimpleDb.java
@@ -1,5 +1,8 @@
 package com.back.domain.article.db;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -12,6 +15,8 @@ public class SimpleDb {
     final String password;
     // 개발 모드 활성화 여부
     private boolean devMode;
+    //변환된 객체의 정보를 저장
+    private final ObjectMapper objectMapper;
 
     //각 스레드의 Connection을 독립적으로 저장하기 위한 ThreadLocal
     private final ThreadLocal<Connection> connectionThreadLocal;
@@ -23,6 +28,11 @@ public class SimpleDb {
         this.password = password;
         this.devMode = false;
         this.connectionThreadLocal = new ThreadLocal<>();
+        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    ObjectMapper getObjectMapper() {
+        return this.objectMapper;
     }
 
     // 개발자 모드를 설정하는 메서드

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -2,7 +2,9 @@ package com.back.domain.article.db;
 
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Sql {
     private final SimpleDb simpleDb;
@@ -101,20 +103,63 @@ public class Sql {
     }
 
     public int delete() {
+        return update();
+    }
+
+    public List<Map<String, Object>> selectRows() {
         logSql();
 
-        // try-with-resources 구문으로 Connection과 PreparedStatement 자원을 자동 해제
+        List<Map<String, Object>> rows = new ArrayList<>();
+
+        // Connection, PreparedStatement, ResultSet 모두 try-with-resources로 자원 관리
         try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
-             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
+             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim());
+             ResultSet rs = pstmt.executeQuery()) {
 
             bindParams(pstmt);
 
-            // SQL을 실행하고, 영향받은 row의 개수를 반환
-            return pstmt.executeUpdate();
+            // ResultSet의 메타데이터(컬럼 정보)를 루프 시작 전에 한 번만 가져옴
+            ResultSetMetaData metaData = rs.getMetaData();
+            int columnCount = metaData.getColumnCount();
+
+            // while 루프를 돌며 각 row를 처리
+            while (rs.next()) {
+                Map<String, Object> row = new HashMap<>();
+
+                // for 루프를 돌며 현재 row의 모든 컬럼을 Map에 담음
+                for (int i = 1; i <= columnCount; i++) {
+                    // 컬럼명을 가져옴 (AS 별칭이 있을 경우를 대비해 getColumnLabel 사용)
+                    String columnName = metaData.getColumnLabel(i);
+                    // 컬럼의 데이터 값을 가져옴
+                    Object value = rs.getObject(i);
+
+                    // t004 테스트 통과를 위한 타입 변환
+                    if (value instanceof Timestamp) {
+                        // DB의 DATETIME/TIMESTAMP 타입을 Java의 LocalDateTime으로 변환
+                        value = ((Timestamp) value).toLocalDateTime();
+                    } else if (value instanceof Long && metaData.getColumnTypeName(i).equals("BIT")) {
+                        // DB의 BIT(1) 타입을 Java의 boolean으로 변환
+                        value = (long) value == 1;
+                    }
+
+                    row.put(columnName, value);
+                }
+                rows.add(row);
+            }
 
         } catch (SQLException e) {
-            // 예외 발생 시 RuntimeException으로 전환하여 처리 중단
             throw new RuntimeException(e);
         }
+
+        return rows;
+    }
+
+    public Map<String, Object> selectRow() {
+        List<Map<String, Object>> rows = selectRows();
+
+        if (rows.isEmpty()) {
+            return null;
+        }
+        return rows.getFirst();
     }
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -99,4 +99,22 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
+    public int delete() {
+        logSql();
+
+        // try-with-resources 구문으로 Connection과 PreparedStatement 자원을 자동 해제
+        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
+             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
+
+            bindParams(pstmt);
+
+            // SQL을 실행하고, 영향받은 row의 개수를 반환
+            return pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            // 예외 발생 시 RuntimeException으로 전환하여 처리 중단
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -1,9 +1,6 @@
 package com.back.domain.article.db;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,19 +25,71 @@ public class Sql {
         return this;
     }
 
+    //전송된 SQL 쿼리 확인을 위한 메서드
+    private void logSql() {
+        if(simpleDb.isDevMode()){
+            System.out.println("== rawSql ==");
+            System.out.println(rawSql.toString().trim());
+            if(!params.isEmpty()){
+                System.out.println("== params ==");
+                for(Object param : params){
+                    System.out.println(param);
+                }
+            }
+        }
+    }
+
+    //
+    private void bindParams(PreparedStatement pstmt) throws SQLException {
+        for(int i = 0; i < params.size(); i++){
+            pstmt.setObject(i + 1, params.get(i));
+        }
+    }
+
+    /**
+     * INSERT 쿼리를 실행하고, 자동 생성된 ID(Primary Key)를 반환합니다.
+     * @return 생성된 ID. 실패 시 -1 반환
+     */
+    public long insert() {
+        logSql(); // SQL 로그 출력
+        // try-with-resources: conn과 pstmt를 자동으로 close
+        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
+             // RETURN_GENERATED_KEYS 옵션으로 PreparedStatement 생성
+             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim(), Statement.RETURN_GENERATED_KEYS)) {
+
+            bindParams(pstmt); // 파라미터 바인딩
+
+            // INSERT 쿼리 실행
+            pstmt.executeUpdate();
+
+            // 생성된 키(ID) 값을 가져옴
+            try (ResultSet rs = pstmt.getGeneratedKeys()) {
+                // 결과가 있다면
+                if (rs.next()) {
+                    // 첫 번째 컬럼의 ID 값을 long으로 읽어서 반환
+                    return rs.getLong(1);
+                }
+            }
+        } catch (SQLException e) {
+            // 오류 발생 시 런타임 예외로 전환
+            throw new RuntimeException(e);
+        }
+
+        // ID 생성 실패 시 -1 반환
+        return -1;
+    }
+
     /**
      * INSERT, UPDATE, DELETE 등 데이터 변경 쿼리를 실행하고
      * 영향받은 row의 개수를 반환합니다.
      */
     public int update() {
+        logSql();
         // try-with-resources 구문으로 Connection과 PreparedStatement 자원을 자동 해제
         try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
              PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
 
-            // SQL의 '?' 부분에 파라미터를 순서대로 바인딩
-            for (int i = 0; i < params.size(); i++) {
-                pstmt.setObject(i + 1, params.get(i));
-            }
+            bindParams(pstmt);
 
             // SQL을 실행하고, 영향받은 row의 개수를 반환
             return pstmt.executeUpdate();

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -157,6 +157,7 @@ public class Sql {
 
     //혹시 결과가 한개가 아니여도 첫번째 row만 반환
     public Map<String, Object> selectRow() {
+        //실행된 쿼리의 결과 가져오기
         List<Map<String, Object>> rows = selectRows();
 
         if (rows.isEmpty()) {
@@ -167,6 +168,7 @@ public class Sql {
     }
 
     public LocalDateTime selectDatetime() {
+        //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
 
         if (row.isEmpty()) {
@@ -177,7 +179,9 @@ public class Sql {
     }
 
     public Long selectLong() {
+        //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
+
         if (row.isEmpty()) {
             return null;
         }
@@ -187,7 +191,9 @@ public class Sql {
     }
 
     public String selectString() {
+        //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
+
         if (row.isEmpty()) {
             return null;
         }
@@ -197,12 +203,25 @@ public class Sql {
     }
 
     public Boolean selectBoolean() {
+        //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
+
         if (row.isEmpty()) {
             return null;
         }
 
-        //Map에 들어있는 첫 번째 값(Value)을 꺼내서 반환
-        return (Boolean) row.values().iterator().next();
+        Object value = row.values().iterator().next();
+
+        //이미 값이 Boolean 타입일 때 그대로 반환
+        if(value instanceof Boolean){
+            return (Boolean) value;
+        }
+
+        //이미 값이 Number 타입일 때 그대로 반환
+        if (value instanceof Number) {
+            return ((Number) value).longValue() == 1;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -1,10 +1,15 @@
 package com.back.domain.article.db;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Sql {
+    private static final Logger log = LoggerFactory.getLogger(Sql.class);
     private final SimpleDb simpleDb;
     private final StringBuilder rawSql;
     private final List<Object> params;
@@ -46,15 +51,19 @@ public class Sql {
 
     //전송된 SQL 쿼리 확인을 위한 메서드
     private void logSql() {
-        if(simpleDb.isDevMode()){
-            System.out.println("== rawSql ==");
-            System.out.println(rawSql.toString().trim());
-            if(!params.isEmpty()){
-                System.out.println("== params ==");
-                for(Object param : params){
-                    System.out.println(param);
-                }
+        if (simpleDb.isDevMode() && log.isDebugEnabled()) {
+            StringBuilder logMessage = new StringBuilder();
+            logMessage.append("\n==================== Query Log ====================\n");
+            logMessage.append("SQL      : ").append(rawSql.toString().trim());
+
+            if (!params.isEmpty()) {
+                String paramsString = params.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(", "));
+                logMessage.append("\nParams   : [").append(paramsString).append("]");
             }
+            logMessage.append("\n=================================================");
+            log.debug(logMessage.toString());
         }
     }
 

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -187,6 +187,19 @@ public class Sql {
         return rows.getFirst();
     }
 
+    public <T> T selectRow(Class<T> cls) {
+        // 1. 기존 selectRow()를 호출하여 결과를 Map으로 받습니다.
+        Map<String, Object> row = selectRow();
+
+        // 2. 결과가 없으면(null이면) 그대로 null을 반환합니다.
+        if (row == null) {
+            return null;
+        }
+
+        // 3. ObjectMapper를 사용하여 Map을 원하는 클래스(cls)의 객체로 변환하여 반환합니다.
+        return simpleDb.getObjectMapper().convertValue(row, cls);
+    }
+
     public LocalDateTime selectDatetime() {
         //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -168,6 +168,13 @@ public class Sql {
         return rows;
     }
 
+    public <T> List<T> selectRows(Class<T> cls) {
+        List<Map<String, Object>> rows = selectRows();
+        return rows.stream()
+                .map(row -> simpleDb.getObjectMapper().convertValue(row, cls))
+                .toList();
+    }
+
     //혹시 결과가 한개가 아니여도 첫번째 row만 반환
     public Map<String, Object> selectRow() {
         //실행된 쿼리의 결과 가져오기

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -241,4 +241,14 @@ public class Sql {
     }
 
 
+    public List<Long> selectLongs() {
+        List<Long> longList = new ArrayList<>();
+
+        List<Map<String, Object>> rows = selectRows();
+        for (Map<String, Object> row : rows) {
+            Long id = (Long) row.values().iterator().next();
+            longList.add(id);
+        }
+        return longList;
+    }
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -175,4 +175,34 @@ public class Sql {
         //Map에 들어있는 첫 번째 값(Value)을 꺼내서 LocalDateTime으로 형변환 후 반환
         return (LocalDateTime) row.values().iterator().next();
     }
+
+    public Long selectLong() {
+        Map<String, Object> row = selectRow();
+        if (row.isEmpty()) {
+            return null;
+        }
+
+        //Map에 들어있는 첫 번째 값(Value)을 꺼내서 Long으로 형변환 후 반환
+        return (Long) row.values().iterator().next();
+    }
+
+    public String selectString() {
+        Map<String, Object> row = selectRow();
+        if (row.isEmpty()) {
+            return null;
+        }
+
+        //Map에 들어있는 첫 번째 값(Value)을 꺼내서 String으로 형변환 후 반환
+        return row.values().iterator().next().toString();
+    }
+
+    public Boolean selectBoolean() {
+        Map<String, Object> row = selectRow();
+        if (row.isEmpty()) {
+            return null;
+        }
+
+        //Map에 들어있는 첫 번째 값(Value)을 꺼내서 반환
+        return (Boolean) row.values().iterator().next();
+    }
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -1,0 +1,53 @@
+package com.back.domain.article.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Sql {
+    private final SimpleDb simpleDb;
+    private final StringBuilder rawSql;
+    private final List<Object> params;
+
+    Sql(SimpleDb simpleDb) {
+        this.simpleDb = simpleDb;
+        this.rawSql = new StringBuilder();
+        this.params = new ArrayList<>();
+    }
+
+    // SQL 문장과 파라미터를 추가하는 메서드
+    public Sql append(String sql, Object... params) {
+        rawSql.append(sql).append(" ");
+        //받은 파라미터들을 List에 추가
+        for (Object param : params) {
+            this.params.add(param);
+        }
+        return this;
+    }
+
+    /**
+     * INSERT, UPDATE, DELETE 등 데이터 변경 쿼리를 실행하고
+     * 영향받은 row의 개수를 반환합니다.
+     */
+    public int update() {
+        // try-with-resources 구문으로 Connection과 PreparedStatement 자원을 자동 해제
+        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
+             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
+
+            // SQL의 '?' 부분에 파라미터를 순서대로 바인딩
+            for (int i = 0; i < params.size(); i++) {
+                pstmt.setObject(i + 1, params.get(i));
+            }
+
+            // SQL을 실행하고, 영향받은 row의 개수를 반환
+            return pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            // 예외 발생 시 RuntimeException으로 전환하여 처리 중단
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -55,10 +55,12 @@ public class Sql {
      */
     public long insert() {
         logSql(); // SQL 로그 출력
-        // try-with-resources: conn과 pstmt를 자동으로 close
-        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
-             // RETURN_GENERATED_KEYS 옵션으로 PreparedStatement 생성
-             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim(), Statement.RETURN_GENERATED_KEYS)) {
+
+        // simpleDb에서 현재 스레드의 Connection을 받아옴
+        Connection conn = simpleDb.getConnection();
+
+        // Connection은 자동으로 닫지 않고, PreparedStatement만 자동으로 닫도록 try-with-resources 사용
+        try (PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim(), Statement.RETURN_GENERATED_KEYS)) {
 
             bindParams(pstmt); // 파라미터 바인딩
 
@@ -88,9 +90,10 @@ public class Sql {
      */
     public int update() {
         logSql();
-        // try-with-resources 구문으로 Connection과 PreparedStatement 자원을 자동 해제
-        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
-             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
+
+        Connection conn = simpleDb.getConnection();
+
+        try (PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim())) {
 
             bindParams(pstmt);
 
@@ -112,46 +115,41 @@ public class Sql {
 
         List<Map<String, Object>> rows = new ArrayList<>();
 
+        Connection conn = simpleDb.getConnection();
+
         // Connection, PreparedStatement, ResultSet 모두 try-with-resources로 자원 관리
-        try (Connection conn = DriverManager.getConnection(simpleDb.url, simpleDb.user, simpleDb.password);
-             PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim());
-             ResultSet rs = pstmt.executeQuery()) {
+        try (PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim());) {
 
             bindParams(pstmt);
 
-            // ResultSet의 메타데이터(컬럼 정보)를 루프 시작 전에 한 번만 가져옴
-            ResultSetMetaData metaData = rs.getMetaData();
-            int columnCount = metaData.getColumnCount();
+            try (ResultSet rs = pstmt.executeQuery()) {
+                ResultSetMetaData metaData = rs.getMetaData();
 
-            // while 루프를 돌며 각 row를 처리
-            while (rs.next()) {
-                Map<String, Object> row = new HashMap<>();
+                int columnCount = metaData.getColumnCount();
 
-                // for 루프를 돌며 현재 row의 모든 컬럼을 Map에 담음
-                for (int i = 1; i <= columnCount; i++) {
-                    // 컬럼명을 가져옴 (AS 별칭이 있을 경우를 대비해 getColumnLabel 사용)
-                    String columnName = metaData.getColumnLabel(i);
-                    // 컬럼의 데이터 값을 가져옴
-                    Object value = rs.getObject(i);
+                while (rs.next()) {
+                    Map<String, Object> row = new HashMap<>();
 
-                    // t004 테스트 통과를 위한 타입 변환
-                    if (value instanceof Timestamp) {
+                    for (int i = 1; i <= columnCount; i++) {
+                        // 컬럼명을 가져옴 (AS 별칭이 있을 경우를 대비해 getColumnLabel 사용)
+                        String columnName = metaData.getColumnLabel(i);
+
+                        Object value = rs.getObject(i);
                         // DB의 DATETIME/TIMESTAMP 타입을 Java의 LocalDateTime으로 변환
-                        value = ((Timestamp) value).toLocalDateTime();
-                    } else if (value instanceof Long && metaData.getColumnTypeName(i).equals("BIT")) {
-                        // DB의 BIT(1) 타입을 Java의 boolean으로 변환
-                        value = (long) value == 1;
+                        if (value instanceof Timestamp) {
+                            value = ((Timestamp) value).toLocalDateTime();
+                            // DB의 BIT(1) 타입을 Java의 boolean으로 변환
+                        } else if (value instanceof Long && metaData.getColumnTypeName(i).equals("BIT")) {
+                            value = (long) value == 1;
+                        }
+                        row.put(columnName, value);
                     }
-
-                    row.put(columnName, value);
+                    rows.add(row);
                 }
-                rows.add(row);
             }
-
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
-
         return rows;
     }
 
@@ -171,7 +169,7 @@ public class Sql {
         //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
 
-        if (row.isEmpty()) {
+        if (row == null || row.isEmpty()) {
             return null;
         }
         //Map에 들어있는 첫 번째 값(Value)을 꺼내서 LocalDateTime으로 형변환 후 반환

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -2,10 +2,7 @@ package com.back.domain.article.db;
 
 import java.sql.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Sql {
     private final SimpleDb simpleDb;
@@ -22,6 +19,25 @@ public class Sql {
     public Sql append(String sql, Object... params) {
         rawSql.append(sql).append(" ");
         //받은 파라미터들을 List에 추가
+        for (Object param : params) {
+            this.params.add(param);
+        }
+        return this;
+    }
+
+    public Sql appendIn(String sql, Object... params) {
+        int count = params.length;
+
+        if(count==0){
+            return this;
+        }
+        String placehlders = String.join(", ", Collections.nCopies(count, "?"));
+
+        //WHERE id IN (?)를 파라미터의 개수에 맞게 ?를 추가하게 변경
+        String newSql = sql.replace("?",  placehlders);
+
+        rawSql.append(newSql).append(" ");
+
         for (Object param : params) {
             this.params.add(param);
         }
@@ -117,7 +133,6 @@ public class Sql {
 
         Connection conn = simpleDb.getConnection();
 
-        // Connection, PreparedStatement, ResultSet 모두 try-with-resources로 자원 관리
         try (PreparedStatement pstmt = conn.prepareStatement(rawSql.toString().trim());) {
 
             bindParams(pstmt);
@@ -180,6 +195,8 @@ public class Sql {
         //실행된 쿼리의 결과 가져오기
         Map<String, Object> row = selectRow();
 
+        List<Map<String, Object>> rows = new ArrayList<>();
+
         if (row.isEmpty()) {
             return null;
         }
@@ -222,4 +239,6 @@ public class Sql {
 
         return null;
     }
+
+
 }

--- a/src/main/java/com/back/domain/article/db/Sql.java
+++ b/src/main/java/com/back/domain/article/db/Sql.java
@@ -1,6 +1,7 @@
 package com.back.domain.article.db;
 
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -154,12 +155,24 @@ public class Sql {
         return rows;
     }
 
+    //혹시 결과가 한개가 아니여도 첫번째 row만 반환
     public Map<String, Object> selectRow() {
         List<Map<String, Object>> rows = selectRows();
 
         if (rows.isEmpty()) {
             return null;
         }
+        //첫번째 row만 반환
         return rows.getFirst();
+    }
+
+    public LocalDateTime selectDatetime() {
+        Map<String, Object> row = selectRow();
+
+        if (row.isEmpty()) {
+            return null;
+        }
+        //Map에 들어있는 첫 번째 값(Value)을 꺼내서 LocalDateTime으로 형변환 후 반환
+        return (LocalDateTime) row.values().iterator().next();
     }
 }

--- a/src/main/java/com/back/global/logback.xml
+++ b/src/main/java/com/back/global/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 콘솔에 로그를 출력하는 Appender 설정 -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- 로그 출력 형식 지정 -->
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!--
+    모든 로거의 기본 레벨을 INFO로 설정합니다.
+    이렇게 하면 DEBUG 레벨의 SQL 로그는 기본적으로 보이지 않습니다.
+    -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!--
+    우리 프로젝트(`com.back.domain.article.db`) 패키지에서 발생하는 로그만
+    특별히 DEBUG 레벨까지 모두 보여주도록 설정합니다.
+    -->
+    <logger name="com.back.domain.article.db" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+</configuration>

--- a/src/test/java/com/back/BackApplicationTests.java
+++ b/src/test/java/com/back/BackApplicationTests.java
@@ -1,9 +1,7 @@
 package com.back;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class BackApplicationTests {
 
     @Test

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,6 +1,6 @@
 package com.back.simpleDb;
 
-import com.back.Article;
+import com.back.domain.article.article.entity.Article;
 import com.back.domain.article.db.SimpleDb;
 import com.back.domain.article.db.Sql;
 import org.junit.jupiter.api.*;
@@ -300,17 +300,17 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(false);
     }
 
-    @Test
+    /*@Test
     @DisplayName("select, LIKE 사용법")
     public void t012() {
         Sql sql = simpleDb.genSql();
-        /*
+        *//*
         == rawSql ==
         SELECT COUNT(*)
         FROM article
         WHERE id BETWEEN '1' AND '3'
         AND title LIKE CONCAT('%', '제목' '%')
-        */
+        *//*
         sql.append("SELECT COUNT(*)")
                 .append("FROM article")
                 .append("WHERE id BETWEEN ? AND ?", 1, 3)
@@ -325,12 +325,12 @@ public class SimpleDbTest {
     @DisplayName("appendIn")
     public void t013() {
         Sql sql = simpleDb.genSql();
-        /*
+        *//*
         == rawSql ==
         SELECT COUNT(*)
         FROM article
         WHERE id IN ('1', '2', '3')
-        */
+        *//*
         sql.append("SELECT COUNT(*)")
                 .append("FROM article")
                 .appendIn("WHERE id IN (?)", 1, 2, 3);
@@ -346,12 +346,12 @@ public class SimpleDbTest {
         Long[] ids = new Long[]{2L, 1L, 3L};
 
         Sql sql = simpleDb.genSql();
-        /*
+        *//*
         SELECT id
         FROM article
         WHERE id IN ('2', '3', '1')
         ORDER BY FIELD (id, '2', '3', '1')
-        */
+        *//*
         sql.append("SELECT id")
                 .append("FROM article")
                 .appendIn("WHERE id IN (?)", ids)
@@ -366,13 +366,13 @@ public class SimpleDbTest {
     @DisplayName("selectRows, Article")
     public void t015() {
         Sql sql = simpleDb.genSql();
-        /*
+        *//*
         == rawSql ==
         SELECT *
         FROM article
         ORDER BY id ASC
         LIMIT 3
-        */
+        *//*
         sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
         List<Article> articleRows = sql.selectRows(Article.class);
 
@@ -396,12 +396,12 @@ public class SimpleDbTest {
     @DisplayName("selectRow, Article")
     public void t016() {
         Sql sql = simpleDb.genSql();
-        /*
+        *//*
         == rawSql ==
         SELECT *
         FROM article
         WHERE id = 1
-        */
+        *//*
         sql.append("SELECT * FROM article WHERE id = 1");
         Article article = sql.selectRow(Article.class);
 
@@ -535,5 +535,5 @@ public class SimpleDbTest {
                 .selectLong();
 
         assertThat(newCount).isEqualTo(oldCount + 1);
-    }
+    }*/
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -300,17 +300,17 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(false);
     }
 
-    /*@Test
+    @Test
     @DisplayName("select, LIKE 사용법")
     public void t012() {
         Sql sql = simpleDb.genSql();
-        *//*
+        /*
         == rawSql ==
         SELECT COUNT(*)
         FROM article
         WHERE id BETWEEN '1' AND '3'
         AND title LIKE CONCAT('%', '제목' '%')
-        *//*
+        */
         sql.append("SELECT COUNT(*)")
                 .append("FROM article")
                 .append("WHERE id BETWEEN ? AND ?", 1, 3)
@@ -325,12 +325,12 @@ public class SimpleDbTest {
     @DisplayName("appendIn")
     public void t013() {
         Sql sql = simpleDb.genSql();
-        *//*
+        /*
         == rawSql ==
         SELECT COUNT(*)
         FROM article
         WHERE id IN ('1', '2', '3')
-        *//*
+        */
         sql.append("SELECT COUNT(*)")
                 .append("FROM article")
                 .appendIn("WHERE id IN (?)", 1, 2, 3);
@@ -346,12 +346,12 @@ public class SimpleDbTest {
         Long[] ids = new Long[]{2L, 1L, 3L};
 
         Sql sql = simpleDb.genSql();
-        *//*
+        /*
         SELECT id
         FROM article
         WHERE id IN ('2', '3', '1')
         ORDER BY FIELD (id, '2', '3', '1')
-        *//*
+        */
         sql.append("SELECT id")
                 .append("FROM article")
                 .appendIn("WHERE id IN (?)", ids)
@@ -366,13 +366,13 @@ public class SimpleDbTest {
     @DisplayName("selectRows, Article")
     public void t015() {
         Sql sql = simpleDb.genSql();
-        *//*
+        /*
         == rawSql ==
         SELECT *
         FROM article
         ORDER BY id ASC
         LIMIT 3
-        *//*
+        */
         sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
         List<Article> articleRows = sql.selectRows(Article.class);
 
@@ -396,12 +396,12 @@ public class SimpleDbTest {
     @DisplayName("selectRow, Article")
     public void t016() {
         Sql sql = simpleDb.genSql();
-        *//*
+        /*
         == rawSql ==
         SELECT *
         FROM article
         WHERE id = 1
-        *//*
+        */
         sql.append("SELECT * FROM article WHERE id = 1");
         Article article = sql.selectRow(Article.class);
 
@@ -535,5 +535,5 @@ public class SimpleDbTest {
                 .selectLong();
 
         assertThat(newCount).isEqualTo(oldCount + 1);
-    }*/
+    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,8 +1,9 @@
 package com.back.simpleDb;
 
 import com.back.Article;
+import com.back.domain.article.db.SimpleDb;
+import com.back.domain.article.db.Sql;
 import org.junit.jupiter.api.*;
-import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -22,18 +23,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SimpleDbTest {
     private static SimpleDb simpleDb;
 
-    @BeforeAll
+    @BeforeAll //모든 테스트가 실행되기 전에 딱 한번 실행한다.
     public static void beforeAll() {
         simpleDb = new SimpleDb("localhost", "root", "root123414", "simpleDb__test");
-        simpleDb.setDevMode(true);
+        simpleDb.setDevMode(true); // simpleDb 객체를 개발자 모드로 설정
 
         createArticleTable();
     }
 
-    @BeforeEach
+    @BeforeEach //각 테스트가 메서드가 실행되기 직전에 매번 반복해서 실행
     public void beforeEach() {
-        truncateArticleTable();
-        makeArticleTestData();
+        truncateArticleTable(); //article테이블의 모든 데이터 삭제
+        makeArticleTestData(); // 테스트에 필요한 초기 데이터를 삽입
     }
 
     private static void createArticleTable() {


### PR DESCRIPTION
# SimpleDb & Sql 클래스 구조 정리

## 1. 프로젝트 목표
JPA, MyBatis와 같은 데이터베이스 프레임워크의 내부 동작 원리를 이해하기 위해, 가장 기초적인 Java 기술인 **순수 JDBC(Java Database Connectivity)**만을 사용하여 DB 유틸리티 라이브러리를 구현하는 것을 목표로 합니다.

제공된 `SimpleDbTest.java`의 모든 테스트 케이스(t001 ~ t019)를 통과하는 것을 최종 목표로 하며, 이 PR에서는 `t001`부터 `t011`까지의 구현 내용을 다룹니다.

## 2. 핵심 기능 구현 과정
### CUD (Create, Update, Delete) 기능 (t001 ~ t003)
- `t001 (INSERT)`: `sql.insert()` 메서드를 구현했습니다.
   - `Connection.prepareStatement()` 호출 시 `Statement.RETURN_GENERATED_KEYS` 옵션을 추가하여, INSERT 이후 자동 생성된 Primary Key(ID)를 getGeneratedKeys()로 받아올 수 있도록 구현했습니다.
 
- `t002 (UPDATE)`: `sql.update()` 메서드를 구현했습니다.
  - JDBC의 `PreparedStatement.executeUpdate()` 메서드는 `INSERT`, `UPDATE`, `DELETE` 쿼리 실행 후 영향받은 row의 개수를 `int` 타입으로 반환합니다. 이 특징을 활용하여 테스트를 통과시켰습니다.Primary Key(ID)를 getGeneratedKeys()로 받아올 수 있도록 구현했습니다.

- `t003 (DELETE)`: `sql.delete()` 메서드를 구현했습니다.

  - `DELETE`의 JDBC 실행 로직은 `UPDATE`와 완전히 동일하므로, 코드 중복을 피하기 위해 `delete()` 메서드 내부에서 `update()` 메서드를 호출하도록 하여 코드를 재사용했습니다.

### SELECT 조회 기능 (t004 ~ t011)
- `t004 (다중 Row 조회)`: `sql.selectRows()`를 구현하여 SELECT 쿼리의 핵심 조회 로직을 완성했습니다.
   - 1PreparedStatement.executeQuery()1를 통해 `ResultSet`을 얻었습니다.
   - `ResultSet.getMetaData()`를 활용하여 `SELECT *` 처럼 동적인 쿼리 결과의 컬럼명과 개수를 알아내 `List<Map<String, Object>>` 형태로 동적으로 매핑했습니다.
   - DB 타입과 Java 타입 간의 호환성을 위해 아래와 같은 변환 로직을 추가했습니다.
     - `DATETIME/TIMESTAMP` -> `java.time.LocalDateTime`
     - `BIT(1`) -> `java.lang.Boolean`
 
- `t002 (UPDATE)`: `sql.update()` 메서드를 구현했습니다.
  - JDBC의 `PreparedStatement.executeUpdate()` 메서드는 `INSERT`, `UPDATE`, `DELETE` 쿼리 실행 후 영향받은 row의 개수를 `int` 타입으로 반환합니다. 이 특징을 활용하여 테스트를 통과시켰습니다.Primary Key(ID)를 getGeneratedKeys()로 받아올 수 있도록 구현했습니다.

- `t005` ~ `t011` (단일 Row 및 단일 값 조회): `selectRow()`, `selectDatetime()`, `selectLong()`, `selectString()`, `selectBoolean()` 메서드를 구현했습니다.
  - 코드 재사용 원칙에 따라, 모든 단일 조회 메서드들은 복잡한 JDBC 로직을 다시 구현하는 대신, 이미 완성된 `selectRows()`를 호출하여 그 결과의 첫 번째 값을 가공하여 반환하도록 구현했습니다. (자세한 내용은 아래 트러블슈팅 항목 참고)

### 객체 매핑(Object Mapping) 기능 (t015, t016)
- `필요성: `selectRows()`가 반환하는 `List<Map<String, Object>>`는 사용하기에 다소 불편하므로, 이를 `List<Article>`과 같은 DTO/Entity 객체 리스트로 자동 변환할 필요가 있었습니다.
- 해결책: `Jackson` 라이브러리의 `ObjectMapper`를 도입했습니다.
  - `SimpleDb`에 `ObjectMapper` 인스턴스를 생성하고, `JavaTimeModule`을 등록하여 `LocalDateTime` 타입을 처리할 수 있도록 설정했습니다.
  - `<T> List<T> selectRows(Class<T> cls`)와 `<T> T selectRow(Class<T> cls)` 메서드를 추가하여, `ObjectMapper.convertValue()`를 통해 `Map`을 원하는 클래스의 객체로 변환하는 기능을 구현했습니다.

### 스레드 관리 및 트랜잭션 기반 구축 (t017)
- 문제점: 초기 설계에서는 모든 SQL 실행 시 `DriverManager.getConnection()`을 통해 매번 새로운 DB 커넥션을 생성했습니다. 이 방식으로는 트랜잭션을 처리할 수 없었고, 멀티스레드 환경에서 커넥션 충돌 문제가 있었습니다.
- 해결책: `ThreadLocal<Connection>`을 도입하여 문제를 해결했습니다.
  - `SimpleDb` 클래스에 `ThreadLocal` 필드를 추가하여, 각 스레드가 자신만의 고유한 `Connection` 객체를 할당받고 독립적으로 작업을 수행하도록 보장했습니다.
  - `getConnection()`은 현재 스레드에 할당된 커넥션을 반환하거나, 없을 경우 새로 생성하여 `ThreadLocal`에 저장합니다.
  - `close()`는 현재 스레드가 사용한 커넥션을 안전하게 닫고 `ThreadLocal` 에서 제거하여 메모리 누수를 방지합니다.

트랜잭션 API 구현 (t018, t019)
- 구현 내용: `ThreadLocal`을 통해 스레드별로 커넥션이 유지되는 기반 위에서, `JDBC`의 트랜잭션 제어 API를 사용하여 `startTransaction()`, `commit()`, `rollback()` 메서드를 `SimpleDb`에 구현했습니다.

  - `startTransaction()`: `connection.setAutoCommit(false)`를 호출하여 자동 커밋 모드를 해제하고 트랜잭션을 시작합니다.

  - `commit()`: `connection.commit()`을 호출하여 트랜잭션 내의 모든 작업을 DB에 영구적으로 반영합니다.

  - `rollback()`: `connection.rollback()`을 호출하여 트랜잭션 내의 모든 작업을 취소하고 이전 상태로 되돌립니다.

## 3. 트러블슈팅 및 주요 결정사항

### 코드 중복 제거

- **문제점:** 초기 `insert()`와 `update()` 메서드에는 SQL 로그 출력과 파라미터 바인딩(PreparedStatement.setObject) 로직이 중복되어 있었습니다.
- **해결책** `logSql()`과 `bindParams()`라는 private 헬퍼 메서드를 만들어 공통 로직을 분리했습니다. 이를 통해 코드의 중복을 제거하고 각 메서드의 역할을 명확히 하여 유지보수성을 향상시켰습니다.

### 단일 조회 메서드의 구현 방식 결정 (재사용 vs. 개별 구현)
- **문제점:** `selectRow()`, `selectLong()` 같은 메서드들을 각각 JDBC 코드로 구현할지, 아니면 `selectRows()`를 재사용할지 고민했습니다.
- **결정:** `selectRows()`를 재사용하는 방식을 채택했습니다.
- **해결책** 개별 구현 시 약간의 성능 이점이 있을 수 있으나, 모든 데이터 변환 로직이 `selectRows()` 한 곳에 집중되어 있어 유지보수성이 압도적으로 뛰어나다고 판단했습니다. 예를 들어, 새로운 DB 타입 변환 규칙이 추가될 때 `selectRows()`만 수정하면 다른 모든 메서드에 자동으로 반영되는 장점이 있습니다.

### Jackson 객체 매핑 시 필드명 불일치

- **문제점:** `Article`레코드에 `boolean isBlind` 필드를 선언하면, `Jackson`라이브러리는 기본적으로 `is`접두사를 제거하고 `blind`라는 이름의 속성으로 인식한다.

- **해결책:** `@JsonProperty("isBlind")` 어노테이션을 `Article` 레코드에 추가하여, `isBlind` 필드와 DB 컬럼명이 정확히 매핑되도록 문제를 해결했습니다.

### 로깅 시스템 개선

- **문제점:** 기존 logSql() 메서드는 System.out.println을 사용하여, 로그 레벨 제어나 형식 변경이 어려운 비표준적인 방식이었습니다.
- **해결책:** 표준 로깅 프레임워크인 SLF4J와 그 구현체 Logback을 도입했습니다.
  - build.gradle.kts에 logback-classic 의존성을 추가했습니다.
  - Sql 클래스에 private static final Logger를 선언하고, logSql()이 log.debug()를 사용하도록 수정하여 로그의 가독성과 관리 효율을 높였습니다.
  - logback.xml 설정 파일을 추가하여, 평소에는 INFO 레벨 이상의 로그만 출력하고 SimpleDb 관련 로그만 DEBUG 레벨까지 상세히 볼 수 있도록 구성했습니다.